### PR TITLE
Mixin ordering compat with NEID

### DIFF
--- a/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
@@ -22,8 +22,7 @@ public abstract class MixinAnvilChunkLoader {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/chunk/storage/AnvilChunkLoader;readChunkFromNBT(Lnet/minecraft/world/World;Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/world/chunk/Chunk;"),
-        remap = false
-    )
+        remap = false)
     private void onCheckedReadChunkFromNBT__Async(World world, int x, int z, NBTTagCompound compound,
         CallbackInfoReturnable<Object[]> cir) {
         ChunkFixerUtility.processChunkNBT(compound, world);

--- a/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
@@ -17,7 +17,13 @@ import com.gtnewhorizons.postea.utility.ChunkFixerUtility;
 @Mixin(AnvilChunkLoader.class)
 public abstract class MixinAnvilChunkLoader {
 
-    @Inject(method = "checkedReadChunkFromNBT__Async", at = @At("HEAD"), remap = false)
+    @Inject(
+        method = "checkedReadChunkFromNBT__Async",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/chunk/storage/AnvilChunkLoader;readChunkFromNBT(Lnet/minecraft/world/World;Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/world/chunk/Chunk;"),
+        remap = false
+    )
     private void onCheckedReadChunkFromNBT__Async(World world, int x, int z, NBTTagCompound compound,
         CallbackInfoReturnable<Object[]> cir) {
         ChunkFixerUtility.processChunkNBT(compound, world);


### PR DESCRIPTION
This adjusts the `checkedReadChunkFromNBT__Async` mixin to target a little bit later in the method, which will ensure it runs after NEID does it's chunk pre-processing that is added by https://github.com/GTNewHorizons/NotEnoughIds/pull/18.

This is needed to properly load worlds that have vanilla formatted chunks saved, but also needs https://github.com/GTNewHorizons/NotEnoughIds/pull/18 to work