### PR TITLE
Compat patches for Vanilla/ChunkAPI/EndlessIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ BlockReplacementManager.addBlockReplacement("minecraft:grass", blockTransformer)
 
 ```java
 Function<NBTTagCompound, NBTTagCompound> itemTransformer = (tag) -> {
-  tag.setShort("id", (short) Item.getIdFromItem(Items.gold_ingot));
+  // Use the utility method for compatibility with NEID/EndlessIDs
+  IDExtenderCompat.setItemStackID(tag, Item.getIdFromItem(Items.gold_ingot));
   return tag;
 };
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
-    api('com.github.GTNewHorizons:NotEnoughIds:2.1.6:dev')
     api("com.github.GTNewHorizons:GTNHLib:0.6.21:dev")
+    compileOnly('com.github.GTNewHorizons:NotEnoughIds:2.1.6:dev')
     compileOnly('com.falsepattern:chunkapi-mc1.7.10:0.6.0:dev')
     compileOnly('com.falsepattern:endlessids-mc1.7.10:1.6.0:dev')
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,4 +2,6 @@
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughIds:2.1.6:dev')
     api("com.github.GTNewHorizons:GTNHLib:0.6.21:dev")
+    compileOnly('com.falsepattern:chunkapi-mc1.7.10:0.6.0:dev')
+    compileOnly('com.falsepattern:endlessids-mc1.7.10:1.6.0:dev')
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,5 +1,12 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
+    maven {
+        name = "mavenpattern"
+        url = "https://mvn.falsepattern.com/releases"
+        content {
+            group("com.falsepattern")
+        }
+    }
     mavenLocal()
 }

--- a/src/main/java/com/gtnewhorizons/postea/api/IDExtenderCompat.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/IDExtenderCompat.java
@@ -1,0 +1,25 @@
+package com.gtnewhorizons.postea.api;
+
+import static net.minecraftforge.common.util.Constants.NBT.TAG_INT;
+import static net.minecraftforge.common.util.Constants.NBT.TAG_SHORT;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+public class IDExtenderCompat {
+
+    public static int getItemStackID(NBTTagCompound tag) {
+        if (tag.hasKey("idExt", TAG_INT)) return tag.getInteger("idExt");
+        else if (tag.hasKey("id", TAG_INT)) return tag.getInteger("id");
+        else if (tag.hasKey("id", TAG_SHORT)) return tag.getShort("id");
+        else return 0;
+    }
+
+    public static void setItemStackID(NBTTagCompound tag, int id) {
+        if (id < 32000) {
+            tag.setShort("id", (short) id);
+        } else {
+            tag.setShort("id", (short) 0);
+            tag.setInteger("idExt", id);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/postea/compat/Compat.java
+++ b/src/main/java/com/gtnewhorizons/postea/compat/Compat.java
@@ -1,0 +1,168 @@
+package com.gtnewhorizons.postea.compat;
+
+import net.minecraft.launchwrapper.Launch;
+import net.minecraft.world.chunk.NibbleArray;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+import com.falsepattern.endlessids.mixin.helpers.SubChunkBlockHook;
+import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
+
+public class Compat {
+
+    private static Boolean chunkapi = null;
+    private static Boolean endlessids = null;
+    private static Boolean neid = null;
+
+    public static boolean chunkapiPresent() {
+        if (chunkapi == null) {
+            boolean present = false;
+            try {
+                present = Launch.classLoader.getClassBytes("com.falsepattern.chunk.internal.core.CoreLoadingPlugin")
+                    != null;
+            } catch (Throwable ignored) {}
+            chunkapi = present;
+        }
+        return chunkapi;
+    }
+
+    public static boolean endlessidsPresent() {
+        if (endlessids == null) {
+            boolean present = false;
+            try {
+                present = Launch.classLoader.getClassBytes("com.falsepattern.endlessids.asm.EndlessIDsCore") != null;
+            } catch (Throwable ignored) {}
+            endlessids = present;
+        }
+        return endlessids;
+    }
+
+    public static boolean neidPresent() {
+        if (neid == null) {
+            boolean present = false;
+            try {
+                present = Launch.classLoader.getClassBytes("com.gtnewhorizons.neid.core.NEIDCore") != null;
+            } catch (Throwable ignored) {}
+            neid = present;
+        }
+        return neid;
+    }
+
+    public static SubChunkAccess getSubChunkAccess(ExtendedBlockStorage subChunk) {
+        if (endlessidsPresent()) {
+            return EndlessIDSCompat.getSubChunkAccess(subChunk);
+        } else if (neidPresent()) {
+            return NEIDCompat.getSubChunkAccess(subChunk);
+        } else {
+            return VanillaCompat.getSubChunkAccess(subChunk);
+        }
+    }
+
+    private static class VanillaCompat {
+
+        public static SubChunkAccess getSubChunkAccess(ExtendedBlockStorage subChunk) {
+            final byte[] lsb = subChunk.getBlockLSBArray();
+            return new SubChunkAccess() {
+
+                private NibbleArray msb = subChunk.getBlockMSBArray();
+
+                @Override
+                public int getBlockId(int x, int y, int z) {
+                    int i = toIndex(x, y, z);
+                    int id = lsb[i] & 0xFF;
+                    if (msb != null) {
+                        id |= msb.get(x, y, z) << 8;
+                    }
+                    return id;
+                }
+
+                @Override
+                public void setBlockId(int x, int y, int z, int id) {
+                    int i = toIndex(x, y, z);
+                    int l = id & 0xFF;
+                    int h = (id >>> 8) & 0xF;
+                    lsb[i] = (byte) l;
+                    if (h == 0 && msb == null) return;
+                    if (msb == null) {
+                        msb = new NibbleArray(lsb.length, 4);
+                        subChunk.setBlockMSBArray(msb);
+                    }
+                    msb.set(x, y, z, h);
+                }
+
+                @Override
+                public int getMeta(int x, int y, int z) {
+                    return subChunk.getExtBlockMetadata(x, y, z);
+                }
+
+                @Override
+                public void setMeta(int x, int y, int z, int meta) {
+                    subChunk.setExtBlockMetadata(x, y, z, meta);
+                }
+            };
+        }
+    }
+
+    private static class EndlessIDSCompat {
+
+        public static SubChunkAccess getSubChunkAccess(ExtendedBlockStorage subChunk) {
+            final SubChunkBlockHook bh = (SubChunkBlockHook) subChunk;
+            return new SubChunkAccess() {
+
+                @Override
+                public int getBlockId(int x, int y, int z) {
+                    return bh.eid$getID(x, y, z);
+                }
+
+                @Override
+                public void setBlockId(int x, int y, int z, int id) {
+                    bh.eid$setID(x, y, z, id);
+                }
+
+                @Override
+                public int getMeta(int x, int y, int z) {
+                    return bh.eid$getMetadata(x, y, z);
+                }
+
+                @Override
+                public void setMeta(int x, int y, int z, int meta) {
+                    bh.eid$setMetadata(x, y, z, meta);
+                }
+            };
+        }
+    }
+
+    private static class NEIDCompat {
+
+        public static SubChunkAccess getSubChunkAccess(ExtendedBlockStorage subChunk) {
+            final IExtendedBlockStorageMixin bh = (IExtendedBlockStorageMixin) subChunk;
+            final short[] blockArray = bh.getBlock16BArray();
+            final short[] metaArray = bh.getBlock16BMetaArray();
+            return new SubChunkAccess() {
+
+                @Override
+                public int getBlockId(int x, int y, int z) {
+                    return blockArray[toIndex(x, y, z)];
+                }
+
+                @Override
+                public void setBlockId(int x, int y, int z, int id) {
+                    blockArray[toIndex(x, y, z)] = (short) id;
+                }
+
+                @Override
+                public int getMeta(int x, int y, int z) {
+                    return metaArray[toIndex(x, y, z)];
+                }
+
+                @Override
+                public void setMeta(int x, int y, int z, int meta) {
+                    metaArray[toIndex(x, y, z)] = (short) meta;
+                }
+            };
+        }
+    }
+
+    private static int toIndex(int x, int y, int z) {
+        return y << 8 | z << 4 | x;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/postea/compat/SubChunkAccess.java
+++ b/src/main/java/com/gtnewhorizons/postea/compat/SubChunkAccess.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizons.postea.compat;
+
+public interface SubChunkAccess {
+
+    int getBlockId(int x, int y, int z);
+
+    void setBlockId(int x, int y, int z, int id);
+
+    int getMeta(int x, int y, int z);
+
+    void setMeta(int x, int y, int z, int meta);
+}

--- a/src/main/java/com/gtnewhorizons/postea/utility/ItemFixerUtility.java
+++ b/src/main/java/com/gtnewhorizons/postea/utility/ItemFixerUtility.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
 
+import com.gtnewhorizons.postea.api.IDExtenderCompat;
 import com.gtnewhorizons.postea.api.ItemStackReplacementManager;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -16,7 +17,7 @@ public abstract class ItemFixerUtility {
         if (tag.hasNoTags()) return;
 
         if (tag.hasKey("id")) {
-            short id = tag.getShort("id");
+            int id = IDExtenderCompat.getItemStackID(tag);
             Item item = Item.getItemById(id);
             if (item == null) return;
             String itemNameInternal = GameRegistry.findUniqueIdentifierFor(item).modId + ":"


### PR DESCRIPTION
- Changed `MixinAnvilChunkLoader` to land correctly for both vanilla, chunkapi, and NEID
- Added a `Compat` helper class that makes `ChunkFixerUtility` compatible with Vanilla, NEID, EIDs
- Added `IDExtenderCompat` that makes `ItemFixedUtility` compatible with Vanilla, EIDs
- Updated the readme to mention the `IDExtenderCompat` helper class