### PR TITLE
Fix falsepattern maven repo inclusion

### DIFF
--- a/repositories.gradle
+++ b/repositories.gradle
@@ -5,7 +5,7 @@ repositories {
         name = "mavenpattern"
         url = "https://mvn.falsepattern.com/releases"
         content {
-            group("com.falsepattern")
+            includeGroup("com.falsepattern")
         }
     }
     mavenLocal()


### PR DESCRIPTION
When #8 was merged there was an error in the repositories.gradle which has caused the publishing to be pushed into `com.falsepattern` on the maven instead of the normal `com.github.GTNewHorizons` path

Currently on the maven, there is no version for 1.1.0 under `com.github.GTNewHorizons` and the version published as 1.1.1 is actually 1.0.14.