### PR TITLE
Biome Replacement System

### DIFF
--- a/src/main/java/com/gtnewhorizons/postea/api/BiomeReplacementManager.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/BiomeReplacementManager.java
@@ -1,0 +1,33 @@
+package com.gtnewhorizons.postea.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import net.minecraft.world.World;
+
+import com.gtnewhorizons.postea.utility.BiomeConversionInfo;
+
+public class BiomeReplacementManager {
+
+    public static final Map<Integer, BiFunction<BiomeConversionInfo, World, BiomeConversionInfo>> biomeReplacementMap = new HashMap<>();
+
+    @SuppressWarnings("unused")
+    public static void addBiomeReplacement(int biomeID,
+        BiFunction<BiomeConversionInfo, World, BiomeConversionInfo> transformer) {
+        biomeReplacementMap.put(biomeID, transformer);
+    }
+
+    public static BiomeConversionInfo getBiomeReplacement(BiomeConversionInfo biomeConversionInfo, World world) {
+
+        BiFunction<BiomeConversionInfo, World, BiomeConversionInfo> transformer = biomeReplacementMap
+            .getOrDefault(biomeConversionInfo.biomeID, null);
+
+        if (transformer == null) {
+            return null;
+        } else {
+            return transformer.apply(biomeConversionInfo, world);
+        }
+    }
+
+}

--- a/src/main/java/com/gtnewhorizons/postea/compat/Compat.java
+++ b/src/main/java/com/gtnewhorizons/postea/compat/Compat.java
@@ -1,9 +1,11 @@
 package com.gtnewhorizons.postea.compat;
 
 import net.minecraft.launchwrapper.Launch;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
+import com.falsepattern.endlessids.mixin.helpers.ChunkBiomeHook;
 import com.falsepattern.endlessids.mixin.helpers.SubChunkBlockHook;
 import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
 
@@ -54,6 +56,26 @@ public class Compat {
             return NEIDCompat.getSubChunkAccess(subChunk);
         } else {
             return VanillaCompat.getSubChunkAccess(subChunk);
+        }
+    }
+
+    public static int getBiomeId(Chunk chunk, int x, int z) {
+        if (endlessidsPresent()) {
+            ChunkBiomeHook chunkHook = (ChunkBiomeHook) chunk;
+            return chunkHook.getBiomeShortArray()[x << 4 | z] & 0xFFFF;
+        } else {
+            // NEID doesn't change anything with biomes, same as vanilla
+            return chunk.getBiomeArray()[x << 4 | z] & 0xFF;
+        }
+    }
+
+    public static void setBiomeId(Chunk chunk, int x, int z, int id) {
+        if (endlessidsPresent()) {
+            ChunkBiomeHook chunkHook = (ChunkBiomeHook) chunk;
+            chunkHook.getBiomeShortArray()[x << 4 | z] = (short) id;
+        } else {
+            // NEID doesn't change anything with biomes, same as vanilla
+            chunk.getBiomeArray()[x << 4 | z] = (byte) id;
         }
     }
 

--- a/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
@@ -36,6 +36,7 @@ public abstract class MixinAnvilChunkLoader {
             }
             ChunkFixerUtility.transformNormalBlocks(chunk, ebs, world);
         }
+        ChunkFixerUtility.transformBiomes(chunk, world);
     }
 
     @Inject(

--- a/src/main/java/com/gtnewhorizons/postea/utility/BiomeConversionInfo.java
+++ b/src/main/java/com/gtnewhorizons/postea/utility/BiomeConversionInfo.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizons.postea.utility;
+
+public final class BiomeConversionInfo {
+
+    public int chunkX;
+    public int chunkZ;
+
+    public int x;
+    public int z;
+
+    public int biomeID;
+}

--- a/src/main/java/com/gtnewhorizons/postea/utility/ChunkFixerUtility.java
+++ b/src/main/java/com/gtnewhorizons/postea/utility/ChunkFixerUtility.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
+import com.gtnewhorizons.postea.api.BiomeReplacementManager;
 import com.gtnewhorizons.postea.api.BlockReplacementManager;
 import com.gtnewhorizons.postea.api.TileEntityReplacementManager;
 import com.gtnewhorizons.postea.compat.Compat;
@@ -31,6 +32,27 @@ public class ChunkFixerUtility {
 
     private static final int AIR_ID = 0;
     private static final HashMap<Block, String> loadedBlocks = new HashMap<>();
+
+    public static void transformBiomes(Chunk chunk, World world) {
+
+        for (int z = 0; z < 16; z++) {
+            for (int x = 0; x < 16; x++) {
+                BiomeConversionInfo conversionInfo = new BiomeConversionInfo();
+                conversionInfo.chunkX = chunk.xPosition;
+                conversionInfo.chunkZ = chunk.zPosition;
+                conversionInfo.x = x;
+                conversionInfo.z = z;
+                conversionInfo.biomeID = Compat.getBiomeId(chunk, x, z);
+
+                BiomeConversionInfo output = BiomeReplacementManager.getBiomeReplacement(conversionInfo, world);
+
+                if (output != null) {
+                    Compat.setBiomeId(chunk, x, z, output.biomeID);
+                }
+            }
+        }
+
+    }
 
     public static void transformNormalBlocks(Chunk chunk, ExtendedBlockStorage ebs, World world) {
 


### PR DESCRIPTION
Adds a hook for mods to register Biome transfers. This allows changing the biome ID of individual x,z columns within a chunk. I've tested this with a simple mod on my local server, but haven't tested with EndlessIDs, though the compat is straight forward and should probably work.