### PR TITLE
Use FMLModIdMappingEvent for numeric id mapping

### DIFF
--- a/src/main/java/com/gtnewhorizons/postea/Postea.java
+++ b/src/main/java/com/gtnewhorizons/postea/Postea.java
@@ -6,8 +6,8 @@ import static com.gtnewhorizons.postea.api.BlockReplacementManager.posteaMarkedI
 import net.minecraft.block.Block;
 
 import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.event.FMLModIdMappingEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 
 @Mod(
@@ -26,7 +26,8 @@ public class Postea {
     public void preInit(FMLPreInitializationEvent event) {}
 
     @Mod.EventHandler
-    public void onServerStarting(FMLServerAboutToStartEvent event) {
+    public void onIdMappingsChanged(FMLModIdMappingEvent event) {
+        posteaMarkedIDs.clear();
         for (String name : blockReplacementMap.keySet()) {
             Block block = Block.getBlockFromName(name);
             if (block != null) {


### PR DESCRIPTION
If a world used to have more mods that are now removed, and its items got remapped to a new mod (e.g. remapping ExtraUtilities blocks to UIE dummies for them), then the numeric item ids get shuffled around when the world is loaded, which is *after* the `FMLServerAboutToStartEvent`.
`FMLModIdMappingEvent` is fired in `GameData.injectWorldIDMap` which seems to be where the IDs are shuffled.