### PR TITLE
Provide chunk to tile entity transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ TileEntityReplacementManager.tileEntityTransformer("GT_TileEntity_Ores", (tag, w
 #### b. We do the same here, but now we convert a Furnace TE to a chest TE. We also need to convert the underlying block to a chest. In addtion to this we can provide a transformer that can edit the NBTTagCompound of the TE. This is useful for converting NBT data from one format to another. Here we simply edit the NBT to place stone in the middle slot.
 
 ```java
-TileEntityReplacementManager.tileEntityTransformer("Chest", (tag, world) -> {
+TileEntityReplacementManager.tileEntityTransformer("Furnace", (tag, world, chunk) -> {
   return new BlockInfo(Blocks.chest, 0, Postea::chestTransformer);
 });
 
@@ -52,6 +52,7 @@ private static NBTTagCompound chestTransformer(NBTTagCompound oldTag) {
   return newTag;
 }
 ```
+Remember that unlike items, tile entities manually store every tag of their nbt data individually, meaning that any additional tags will be discarded and cannot be used to store additional data unless it is already a part of the new tile entity.
 
 ### 2. Normal Block Transformation
 

--- a/src/main/java/com/gtnewhorizons/postea/api/TileEntityReplacementManager.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/TileEntityReplacementManager.java
@@ -9,6 +9,7 @@ import net.minecraft.world.chunk.Chunk;
 
 import com.gtnewhorizons.postea.utility.BlockInfo;
 
+@SuppressWarnings("unused")
 public class TileEntityReplacementManager {
 
     private static final HashMap<String, TriFunction<NBTTagCompound, World, Chunk, BlockInfo>> tileEntityToNormalBlockTransformer = new HashMap<>();

--- a/src/main/java/com/gtnewhorizons/postea/api/TileEntityReplacementManager.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/TileEntityReplacementManager.java
@@ -5,19 +5,26 @@ import java.util.function.BiFunction;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 
 import com.gtnewhorizons.postea.utility.BlockInfo;
 
 public class TileEntityReplacementManager {
 
-    private static final HashMap<String, BiFunction<NBTTagCompound, World, BlockInfo>> tileEntityToNormalBlockTransformer = new HashMap<>();
+    private static final HashMap<String, TriFunction<NBTTagCompound, World, Chunk, BlockInfo>> tileEntityToNormalBlockTransformer = new HashMap<>();
 
     public static void tileEntityTransformer(String tileEntityId,
         BiFunction<NBTTagCompound, World, BlockInfo> transformerFunction) {
+        tileEntityToNormalBlockTransformer
+            .put(tileEntityId, (tag, world, chunk) -> transformerFunction.apply(tag, world));
+    }
+
+    public static void tileEntityTransformer(String tileEntityId,
+        TriFunction<NBTTagCompound, World, Chunk, BlockInfo> transformerFunction) {
         tileEntityToNormalBlockTransformer.put(tileEntityId, transformerFunction);
     }
 
-    public static BiFunction<NBTTagCompound, World, BlockInfo> getTileEntityToNormalBlockTransformerFunction(
+    public static TriFunction<NBTTagCompound, World, Chunk, BlockInfo> getTileEntityToNormalBlockTransformerFunction(
         String tileEntityId) {
         return tileEntityToNormalBlockTransformer.getOrDefault(tileEntityId, null);
     }

--- a/src/main/java/com/gtnewhorizons/postea/api/TileEntityReplacementManager.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/TileEntityReplacementManager.java
@@ -14,12 +14,25 @@ public class TileEntityReplacementManager {
 
     private static final HashMap<String, TriFunction<NBTTagCompound, World, Chunk, BlockInfo>> tileEntityToNormalBlockTransformer = new HashMap<>();
 
+    /**
+     * @deprecated Superseded by {@link #tileEntityTransformer(String, TriFunction)}.
+     */
+    @Deprecated
     public static void tileEntityTransformer(String tileEntityId,
         BiFunction<NBTTagCompound, World, BlockInfo> transformerFunction) {
         tileEntityToNormalBlockTransformer
             .put(tileEntityId, (tag, world, chunk) -> transformerFunction.apply(tag, world));
     }
 
+    /**
+     * Register a callback function to transform a tile entity before it's loaded.
+     * Callback returns a {@link BlockInfo} which the tile entity will be transformed into.</br>
+     * Note that the callback will be called before the world is fully loaded, and world.getBlock will throw an error.
+     * Use chunk.getBlock(x & 15, y, z & 15) instead.
+     *
+     * @param tileEntityId        ID of the tile entity to be transformed
+     * @param transformerFunction Callback function to transforms the tile entity
+     */
     public static void tileEntityTransformer(String tileEntityId,
         TriFunction<NBTTagCompound, World, Chunk, BlockInfo> transformerFunction) {
         tileEntityToNormalBlockTransformer.put(tileEntityId, transformerFunction);

--- a/src/main/java/com/gtnewhorizons/postea/api/TriFunction.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/TriFunction.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizons.postea.api;
+
+@FunctionalInterface
+public interface TriFunction<T, U, O, R> {
+
+    R apply(T t, U u, O o);
+}

--- a/src/main/java/com/gtnewhorizons/postea/utility/ChunkFixerUtility.java
+++ b/src/main/java/com/gtnewhorizons/postea/utility/ChunkFixerUtility.java
@@ -6,7 +6,6 @@ import static com.gtnewhorizons.postea.utility.PosteaUtilities.getModListHash;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import net.minecraft.block.Block;
@@ -18,6 +17,7 @@ import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
 import com.gtnewhorizons.postea.api.BlockReplacementManager;
 import com.gtnewhorizons.postea.api.TileEntityReplacementManager;
+import com.gtnewhorizons.postea.api.TriFunction;
 import com.gtnewhorizons.postea.compat.Compat;
 import com.gtnewhorizons.postea.compat.SubChunkAccess;
 
@@ -86,7 +86,8 @@ public class ChunkFixerUtility {
 
         Pair<List<ConversionInfo>, NBTTagList> output = adjustTileEntities(
             levelCompoundTag.getTagList("TileEntities", 10),
-            world);
+            world,
+            chunk);
         List<ConversionInfo> conversionInfoList = output.first();
         NBTTagList tileEntities = output.second();
 
@@ -116,7 +117,8 @@ public class ChunkFixerUtility {
         }
     }
 
-    private static Pair<List<ConversionInfo>, NBTTagList> adjustTileEntities(NBTTagList tileEntities, World world) {
+    private static Pair<List<ConversionInfo>, NBTTagList> adjustTileEntities(NBTTagList tileEntities, World world,
+        Chunk chunk) {
         List<ConversionInfo> conversionInfo = new ArrayList<>();
 
         NBTTagList tileEntitiesCopy = new NBTTagList();
@@ -126,7 +128,7 @@ public class ChunkFixerUtility {
             String tileEntityId = tileEntity.getString("id");
 
             // Check if we have a transformer registered for this tile entity ID
-            BiFunction<NBTTagCompound, World, BlockInfo> transformationFunction = TileEntityReplacementManager
+            TriFunction<NBTTagCompound, World, Chunk, BlockInfo> transformationFunction = TileEntityReplacementManager
                 .getTileEntityToNormalBlockTransformerFunction(tileEntityId);
 
             if (transformationFunction != null) {
@@ -134,7 +136,7 @@ public class ChunkFixerUtility {
                 int y = tileEntity.getInteger("y");
                 int z = tileEntity.getInteger("z");
 
-                BlockInfo blockInfo = transformationFunction.apply(tileEntity, world);
+                BlockInfo blockInfo = transformationFunction.apply(tileEntity, world, chunk);
                 if (blockInfo == null) {
                     // Do nothing.
                     tileEntitiesCopy.appendTag(tileEntity);


### PR DESCRIPTION
While the world initially loads calling `world.getBlock` inside of a tile entity transformer throws an error, presumably because it hasn't been fully loaded yet. This means that tile entity transformers can't access the underlying Block instance at their coordinates.
This will allow them to use `chunk.getBlock(x & 15, y, z & 15)` to get the block.