### PR TITLE
Enforce non-nullability of return values for transformation handlers

### DIFF
--- a/src/main/java/com/gtnewhorizons/postea/api/BlockReplacementManager.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/BlockReplacementManager.java
@@ -1,14 +1,12 @@
 package com.gtnewhorizons.postea.api;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 
 import net.minecraft.block.Block;
 import net.minecraftforge.oredict.OreDictionary;
 
-import com.gtnewhorizons.postea.utility.BlockConversionInfo;
 import com.gtnewhorizons.postea.utility.IDRegistry;
 import com.gtnewhorizons.postea.utility.MissingMappingHandler;
 import com.gtnewhorizons.postea.utility.SimpleTransformationRegistry;
@@ -48,7 +46,7 @@ public abstract class BlockReplacementManager {
      * @param transformer The transformer to apply.
      */
     @SuppressWarnings("unused")
-    public static void addTransformationHandler(String originalId, Function<BlockConversionInfo, Boolean> transformer) {
+    public static void addTransformationHandler(String originalId, IBlockTransformationHandler transformer) {
         if (originalId == null) throw new IllegalArgumentException("original id is null");
         if (transformer == null) throw new IllegalArgumentException("transformer is null");
         TransformerRegistry.addBlockTransformer(originalId, transformer);

--- a/src/main/java/com/gtnewhorizons/postea/api/IBlockTransformationHandler.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/IBlockTransformationHandler.java
@@ -1,0 +1,9 @@
+package com.gtnewhorizons.postea.api;
+
+import com.gtnewhorizons.postea.utility.BlockConversionInfo;
+
+@FunctionalInterface
+public interface IBlockTransformationHandler {
+
+    boolean apply(BlockConversionInfo info);
+}

--- a/src/main/java/com/gtnewhorizons/postea/api/IItemStackTransformationHandler.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/IItemStackTransformationHandler.java
@@ -1,0 +1,9 @@
+package com.gtnewhorizons.postea.api;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+@FunctionalInterface
+public interface IItemStackTransformationHandler {
+
+    boolean apply(String originalId, NBTTagCompound stack);
+}

--- a/src/main/java/com/gtnewhorizons/postea/api/ItemStackReplacementManager.java
+++ b/src/main/java/com/gtnewhorizons/postea/api/ItemStackReplacementManager.java
@@ -1,6 +1,5 @@
 package com.gtnewhorizons.postea.api;
 
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
@@ -8,7 +7,6 @@ import javax.annotation.Nonnull;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.gtnewhorizons.postea.utility.IDRegistry;
@@ -52,8 +50,7 @@ public abstract class ItemStackReplacementManager {
      * @param transformer The transformer to apply.
      */
     @SuppressWarnings("unused")
-    public static void addTransformationHandler(String originalId,
-        BiFunction<String, NBTTagCompound, Boolean> transformer) {
+    public static void addTransformationHandler(String originalId, IItemStackTransformationHandler transformer) {
         if (originalId == null) throw new IllegalArgumentException("original id is null");
         if (transformer == null) throw new IllegalArgumentException("transformer is null");
         TransformerRegistry.addStackTransformer(originalId, transformer);

--- a/src/main/java/com/gtnewhorizons/postea/utility/SimpleTransformationRegistry.java
+++ b/src/main/java/com/gtnewhorizons/postea/utility/SimpleTransformationRegistry.java
@@ -1,8 +1,6 @@
 package com.gtnewhorizons.postea.utility;
 
 import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
@@ -10,7 +8,9 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.oredict.OreDictionary;
 
+import com.gtnewhorizons.postea.api.IBlockTransformationHandler;
 import com.gtnewhorizons.postea.api.IDExtenderCompat;
+import com.gtnewhorizons.postea.api.IItemStackTransformationHandler;
 
 /**
  * A registry for simple item and block transformations. A common use case is mod removal, replacements or deprecations.
@@ -114,7 +114,7 @@ public class SimpleTransformationRegistry {
      *
      * @implNote This implementation has constant-time runtime.
      */
-    private static class SimpleBlockTransformationHandler implements Function<BlockConversionInfo, Boolean> {
+    private static class SimpleBlockTransformationHandler implements IBlockTransformationHandler {
 
         private final Map<Integer, SimpleTransformationMap.Value<Block>> metaMap;
 
@@ -123,7 +123,7 @@ public class SimpleTransformationRegistry {
         }
 
         @Override
-        public Boolean apply(BlockConversionInfo info) {
+        public boolean apply(BlockConversionInfo info) {
             SimpleTransformationMap.Value<Block> mapping = SimpleTransformationMap
                 .getFromSubMap(metaMap, info.metadata);
             if (mapping == null || mapping.targetRuntimeId <= -1) return false;
@@ -176,7 +176,7 @@ public class SimpleTransformationRegistry {
      *
      * @implNote This implementation has constant-time runtime.
      */
-    private static class SimpleItemTransformationHandler implements BiFunction<String, NBTTagCompound, Boolean> {
+    private static class SimpleItemTransformationHandler implements IItemStackTransformationHandler {
 
         private final Map<Integer, SimpleTransformationMap.Value<Item>> metaMap;
 
@@ -185,7 +185,7 @@ public class SimpleTransformationRegistry {
         }
 
         @Override
-        public Boolean apply(String originalId, NBTTagCompound tag) {
+        public boolean apply(String originalId, NBTTagCompound tag) {
             short meta = tag.getShort("Damage");
             SimpleTransformationMap.Value<Item> mapping = SimpleTransformationMap.getFromSubMap(metaMap, meta);
             if (mapping == null || mapping.targetRuntimeId <= -1) return false;

--- a/src/main/java/com/gtnewhorizons/postea/utility/TransformerRegistry.java
+++ b/src/main/java/com/gtnewhorizons/postea/utility/TransformerRegistry.java
@@ -2,8 +2,6 @@ package com.gtnewhorizons.postea.utility;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,7 +13,9 @@ import net.minecraft.world.chunk.Chunk;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.collect.LinkedListMultimap;
+import com.gtnewhorizons.postea.api.IBlockTransformationHandler;
 import com.gtnewhorizons.postea.api.IDExtenderCompat;
+import com.gtnewhorizons.postea.api.IItemStackTransformationHandler;
 import com.gtnewhorizons.postea.api.TriFunction;
 
 import cpw.mods.fml.common.Loader;
@@ -27,9 +27,9 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
  */
 public class TransformerRegistry {
 
-    private static final LinkedListMultimap<String, BiFunction<String, NBTTagCompound, Boolean>> ITEM_REPLACEMENT_MAP = LinkedListMultimap
+    private static final LinkedListMultimap<String, IItemStackTransformationHandler> ITEM_REPLACEMENT_MAP = LinkedListMultimap
         .create();
-    public static final LinkedListMultimap<String, Function<BlockConversionInfo, Boolean>> BLOCK_REPLACEMENT_MAP = LinkedListMultimap
+    public static final LinkedListMultimap<String, IBlockTransformationHandler> BLOCK_REPLACEMENT_MAP = LinkedListMultimap
         .create();
     private static final LinkedListMultimap<String, TriFunction<NBTTagCompound, World, Chunk, BlockInfo>> TILE_ENTITY_REPLACEMENT_MAP = LinkedListMultimap
         .create();
@@ -38,13 +38,13 @@ public class TransformerRegistry {
      * Pivoting on the id is faster than pivoting on the strings so this should help with perf a bit.
      * Generated during the mapping update event whilst entering/loading a world.
      */
-    private static final Int2ObjectOpenHashMap<Pair<String, List<BiFunction<String, NBTTagCompound, Boolean>>>> RUNTIME_ITEM_REPLACEMENT_MAP = new Int2ObjectOpenHashMap<>();
+    private static final Int2ObjectOpenHashMap<Pair<String, List<IItemStackTransformationHandler>>> RUNTIME_ITEM_REPLACEMENT_MAP = new Int2ObjectOpenHashMap<>();
     /**
      * Map of blockIO -> originalName+transformationHandler.
      * Pivoting on the id is faster than pivoting on the strings so this should help with perf a bit.
      * Generated during the mapping update event whilst entering/loading a world.
      */
-    private static final Int2ObjectOpenHashMap<Pair<String, List<Function<BlockConversionInfo, Boolean>>>> RUNTIME_BLOCK_REPLACEMENT_MAP = new Int2ObjectOpenHashMap<>();
+    private static final Int2ObjectOpenHashMap<Pair<String, List<IBlockTransformationHandler>>> RUNTIME_BLOCK_REPLACEMENT_MAP = new Int2ObjectOpenHashMap<>();
 
     // region FML Life Cycle handlers
     /**
@@ -94,7 +94,7 @@ public class TransformerRegistry {
      * @param transformer The transformation handler that will execute a transformation on the block.
      */
     public static void addBlockTransformer(@Nonnull String originalId,
-        @Nonnull Function<BlockConversionInfo, Boolean> transformer) {
+        @Nonnull IBlockTransformationHandler transformer) {
         BLOCK_REPLACEMENT_MAP.put(originalId, transformer);
     }
 
@@ -112,7 +112,7 @@ public class TransformerRegistry {
      * @param transformer The transformation handler that will execute a transformation on the block.
      */
     public static void addStackTransformer(@Nonnull String originalId,
-        @Nonnull BiFunction<String, NBTTagCompound, Boolean> transformer) {
+        @Nonnull IItemStackTransformationHandler transformer) {
         ITEM_REPLACEMENT_MAP.put(originalId, transformer);
     }
 
@@ -137,7 +137,7 @@ public class TransformerRegistry {
     // region transformation handlers
     public static @Nullable BlockConversionInfo getBlockReplacement(int blockId, byte metadata, World world, int x,
         int y, int z) {
-        Pair<String, List<Function<BlockConversionInfo, Boolean>>> data = RUNTIME_BLOCK_REPLACEMENT_MAP.get(blockId);
+        Pair<String, List<IBlockTransformationHandler>> data = RUNTIME_BLOCK_REPLACEMENT_MAP.get(blockId);
         if (data == null) return null;
         BlockConversionInfo blockConversionInfo = new BlockConversionInfo(
             // transparently maps the id to the original id if it's a dummy id
@@ -148,7 +148,7 @@ public class TransformerRegistry {
             y,
             z,
             world);
-        for (Function<BlockConversionInfo, Boolean> transformer : data.getValue()) {
+        for (IBlockTransformationHandler transformer : data.getValue()) {
             if (transformer.apply(blockConversionInfo)) {
                 return blockConversionInfo;
             }
@@ -161,12 +161,12 @@ public class TransformerRegistry {
         if (tag.hasNoTags() || !tag.hasKey("id")) return;
         // get handler
         int id = IDExtenderCompat.getItemStackID(tag);
-        Pair<String, List<BiFunction<String, NBTTagCompound, Boolean>>> data = RUNTIME_ITEM_REPLACEMENT_MAP.get(id);
+        Pair<String, List<IItemStackTransformationHandler>> data = RUNTIME_ITEM_REPLACEMENT_MAP.get(id);
         // abort early if handler not found
         if (data != null && !data.getValue()
             .isEmpty()) {
             // apply handlers
-            for (BiFunction<String, NBTTagCompound, Boolean> transformer : data.getValue()) {
+            for (IItemStackTransformationHandler transformer : data.getValue()) {
                 if (transformer.apply(data.getKey(), tag)) {
                     return;
                 }


### PR DESCRIPTION
I was tempted to add this to the main refactor PR, but chose not to for clarity. It's clearly more prone to errors down the line, so it's better fix it now than never.

The following mods will need dep updates to work properly, since the new interface isn't fully type-analogous (Pointer boolean -> primitive boolean can't be done at runtime).
- [Witching Gadgets](https://github.com/GTNewHorizons/WitchingGadgets)
- [GT5u](https://github.com/GTNewHorizons/GT5-Unofficial)
- [GTNHCoreMod](https://github.com/GTNewHorizons/NewHorizonsCoreMod)

> [!IMPORTANT]
> **GT5u should be updated before the core mod** since the core mod inherits postea via GT5u; WG technically does too, but it's also overriding the dep in its build file (could probably be removed).