### PR TITLE
Fix Chunk API Compatibility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,8 +5,4 @@ dependencies {
     compileOnly('com.falsepattern:chunkapi-mc1.7.10:0.8.2:dev')
     compileOnly('com.falsepattern:endlessids-mc1.7.10:1.7.1:dev')
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.71-GTNH:dev") { transitive = false }
-
-    // for testing EID compat
-    // runtimeOnly('com.falsepattern:chunkapi-mc1.7.10:0.8.2:dev')
-    // runtimeOnly('com.falsepattern:endlessids-mc1.7.10:1.7.1:dev')
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,11 @@
 dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.9.31:dev")
     compileOnly('com.github.GTNewHorizons:NotEnoughIds:2.1.10:dev')
-    compileOnly('com.falsepattern:chunkapi-mc1.7.10:0.6.0:dev')
-    compileOnly('com.falsepattern:endlessids-mc1.7.10:1.6.0:dev')
+    compileOnly('com.falsepattern:chunkapi-mc1.7.10:0.8.2:dev')
+    compileOnly('com.falsepattern:endlessids-mc1.7.10:1.7.1:dev')
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.71-GTNH:dev") { transitive = false }
+
+    // for testing EID compat
+    // runtimeOnly('com.falsepattern:chunkapi-mc1.7.10:0.8.2:dev')
+    // runtimeOnly('com.falsepattern:endlessids-mc1.7.10:1.7.1:dev')
 }

--- a/src/main/java/com/gtnewhorizons/postea/mixins/PosteaLateLoadingPlugin.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/PosteaLateLoadingPlugin.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizons.postea.mixins;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
+import com.gtnewhorizon.gtnhmixins.LateMixin;
+
+import cpw.mods.fml.common.Loader;
+
+@LateMixin
+public final class PosteaLateLoadingPlugin implements ILateMixinLoader {
+
+    @Override
+    public String getMixinConfig() {
+        return "mixins.postea.late.json";
+    }
+
+    @Override
+    public List<String> getMixins(Set<String> loadedCoreMods) {
+        final List<String> mixins = new ArrayList<>();
+        if (Loader.isModLoaded("chunkapi")) {
+            mixins.add("MixinDataRegistryImpl");
+        }
+        return mixins;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/postea/mixins/PosteaLateLoadingPlugin.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/PosteaLateLoadingPlugin.java
@@ -7,8 +7,6 @@ import java.util.Set;
 import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
 import com.gtnewhorizon.gtnhmixins.LateMixin;
 
-import cpw.mods.fml.common.Loader;
-
 @LateMixin
 public final class PosteaLateLoadingPlugin implements ILateMixinLoader {
 
@@ -18,9 +16,9 @@ public final class PosteaLateLoadingPlugin implements ILateMixinLoader {
     }
 
     @Override
-    public List<String> getMixins(Set<String> loadedCoreMods) {
+    public List<String> getMixins(Set<String> loadedMods) {
         final List<String> mixins = new ArrayList<>();
-        if (Loader.isModLoaded("chunkapi")) {
+        if (loadedMods.contains("chunkapi")) {
             mixins.add("MixinDataRegistryImpl");
         }
         return mixins;

--- a/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/early/MixinAnvilChunkLoader.java
@@ -29,7 +29,7 @@ public abstract class MixinAnvilChunkLoader {
         ChunkFixerUtility.onChunkLoaded(cir.getReturnValue());
     }
 
-    @Inject(method = "writeChunkToNBT", at = @At("HEAD"))
+    @Inject(method = "writeChunkToNBT", at = @At("HEAD"), order = 900)
     private void postea$writePosteaChunkCode(Chunk chunk, World world, NBTTagCompound nbtTagCompound, CallbackInfo ci) {
         ChunkFixerUtility.onChunkWrite(chunk, nbtTagCompound);
     }

--- a/src/main/java/com/gtnewhorizons/postea/mixins/late/MixinDataRegistryImpl.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/late/MixinDataRegistryImpl.java
@@ -1,0 +1,25 @@
+package com.gtnewhorizons.postea.mixins.late;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.chunk.Chunk;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.falsepattern.chunk.internal.DataRegistryImpl;
+import com.gtnewhorizons.postea.utility.ChunkFixerUtility;
+
+@Mixin(value = DataRegistryImpl.class, remap = false)
+public abstract class MixinDataRegistryImpl {
+
+    @Inject(
+        method = "readChunkFromNBT(Lnet/minecraft/world/chunk/Chunk;Lnet/minecraft/nbt/NBTTagCompound;)V",
+        at = @At("RETURN"),
+        require = 1)
+    @SuppressWarnings("unused")
+    private static void Postea$chunkReadHook(Chunk chunk, NBTTagCompound chunkNBT, CallbackInfo ci) {
+        ChunkFixerUtility.onChunkRead(chunk, chunk.worldObj, chunkNBT);
+    }
+}

--- a/src/main/java/com/gtnewhorizons/postea/mixins/late/MixinDataRegistryImpl.java
+++ b/src/main/java/com/gtnewhorizons/postea/mixins/late/MixinDataRegistryImpl.java
@@ -18,7 +18,6 @@ public abstract class MixinDataRegistryImpl {
         method = "readChunkFromNBT(Lnet/minecraft/world/chunk/Chunk;Lnet/minecraft/nbt/NBTTagCompound;)V",
         at = @At("RETURN"),
         require = 1)
-    @SuppressWarnings("unused")
     private static void Postea$chunkReadHook(Chunk chunk, NBTTagCompound chunkNBT, CallbackInfo ci) {
         ChunkFixerUtility.onChunkRead(chunk, chunk.worldObj, chunkNBT);
     }

--- a/src/main/resources/mixins.postea.late.json
+++ b/src/main/resources/mixins.postea.late.json
@@ -1,0 +1,8 @@
+{
+  "required": true,
+  "minVersion": "0.8.5-GTNH",
+  "package": "com.gtnewhorizons.postea.mixins.late",
+  "refmap": "mixins.postea.refmap.json",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8"
+}


### PR DESCRIPTION
The addition of ChunkAPI and EndlessIDs to the pack has completely broke the world migrations from postea. This is because it essentially does a full overwrite of the function Postea's mixins are targeting, preventing postea from doing it's thing.

This PR fixes this issue

- Adds a new late mixin targetting ChunkAPI directly since it completely overrides the usual read logic
- Made the write mixin order higher so it gets executed
- Updated EID and ChunkAPI deps

A good way to check if this works right would be to load up a test world with some IC2 crops in experimental 80 and then load that world into exp 91 with the updated postea.

All crops should get automatically migrated.